### PR TITLE
CS-1684 Fix using plugin on Sonarqube with self-signed SSL certificate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codescan-export",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "codescan-export",
   "description": "Export CodeScan issues from the command line",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "CodeScan by VillageChief",
   "bin": {
     "codescan-export": "./bin/run"
   },
-  "bugs": "https://github.com/https://github.com/villagechief/codescan-export/https://github.com/villagechief/codescan-export/issues",
+  "bugs": "https://github.com/villagechief/codescan-export/issues",
   "dependencies": {
     "@oclif/command": "^1.5.14",
     "@oclif/config": "^1.13.0",
@@ -30,7 +30,7 @@
     "/bin",
     "/src"
   ],
-  "homepage": "https://github.com/https://github.com/villagechief/codescan-export/https://github.com/villagechief/codescan-export",
+  "homepage": "https://github.com/villagechief/codescan-export/",
   "keywords": [
     "oclif"
   ],
@@ -39,7 +39,7 @@
   "oclif": {
     "bin": "codescan-export"
   },
-  "repository": "https://github.com/villagechief/codescan-export/https://github.com/villagechief/codescan-export",
+  "repository": "https://github.com/villagechief/codescan-export",
   "scripts": {
     "posttest": "eslint .",
     "test": "nyc mocha --forbid-only \"test/**/*.test.js\""

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ class CodescanExportCommand extends Command {
     options = options || {
     };
     options.json = options.json || true;
-    options.rejectUnauthorized = false;
+    options.rejectUnauthorized = this.verifySslCa;
     options.headers = options.headers || {};
     options['uri'] = this.server + path;
     options['headers']["Authorization"] = "Basic " + new Buffer(this.token + ":").toString("base64");
@@ -152,6 +152,7 @@ class CodescanExportCommand extends Command {
     this.quote = flags.quote || '"';
     this.delimiter = flags.delimiter || ',';
     this.escape = flags.escape || '"';
+    this.verifySslCa = flags.verifySslCa;
 
     this.writeRow([
       "Creation Date",
@@ -265,6 +266,8 @@ CodescanExportCommand.flags = {
     "Possible values: CODE_SMELL, BUG, VULNERABILITY, SECURITY_HOTSPOT\n" +
     "Default value: BUG,VULNERABILITY,CODE_SMELL\n" +
     "Example value: CODE_SMELL,BUG"}),
+
+  verifySslCa: flags.boolean({default: true, description: "Use --no-verifySslCa to skip verification of the server certificate against the list of supplied CAs.\nThis can be helpful in case of using self-signed certificates.\n", allowNo: true}),
 }
 CodescanExportCommand.args = [
   {name: 'organizationKey'},

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ class CodescanExportCommand extends Command {
     options = options || {
     };
     options.json = options.json || true;
+    options.rejectUnauthorized = false;
     options.headers = options.headers || {};
     options['uri'] = this.server + path;
     options['headers']["Authorization"] = "Basic " + new Buffer(this.token + ":").toString("base64");


### PR DESCRIPTION
Added the new `--[no-]verifySslCa` flag.

By default the SSL certificate verification is enabled. It can be disabled by adding  --no-verifySslCa.